### PR TITLE
Allow `FloatingNotificationBanner` to pass `sideViewSize` to parent

### DIFF
--- a/NotificationBanner/Classes/FloatingNotificationBanner.swift
+++ b/NotificationBanner/Classes/FloatingNotificationBanner.swift
@@ -34,6 +34,7 @@ open class FloatingNotificationBanner: GrowingNotificationBanner {
                 style: BannerStyle = .info,
                 colors: BannerColorsProtocol? = nil,
                 iconPosition: IconPosition = .center,
+                sideViewSize: CGFloat = 24,
                 horizontalPadding: CGFloat? = nil,
                 verticalPadding: CGFloat? = nil,
                 viewsSpacing: CGFloat? = nil) {
@@ -45,6 +46,7 @@ open class FloatingNotificationBanner: GrowingNotificationBanner {
                    style: style,
                    colors: colors,
                    iconPosition: iconPosition,
+                   sideViewSize: sideViewSize,
                    horizontalPadding: horizontalPadding,
                    verticalPadding: verticalPadding,
                    viewsSpacing: viewsSpacing)


### PR DESCRIPTION
`FloatingNotificationBanner` lacks the ability to specify `sideViewSize` which is actually available within `GrowingNotificationBanner`'s initializer.
Hardcoded value of 24 is derived from default value for corresponding parameter of existing initializer (see `GrowingNotificationBanner.init(...)`).